### PR TITLE
remove LFS files from testutil

### DIFF
--- a/encryptiontest/generators_darwin_test.go
+++ b/encryptiontest/generators_darwin_test.go
@@ -17,6 +17,10 @@ var reliableGenerators = []generatorTestCase{
 	// small amounts of random data (<160bytes) is fine, but it's not well
 	// suited to this test.
 	//	{"cryptorand", cryptorand, false, true,true},
-	{"divx", divx, true, false, false},
-	{"zip", zip, true, false, false},
+
+	// divx/zip require a precomputed random file to test with
+	// due to lfs limits this file is no longer being servered by grailbio
+	// The file may be downloaded via LFS from 39b3ca80f18 or earlier
+	//{"divx", divx, true, false, false},
+	//{"zip", zip, true, false, false},
 }

--- a/encryptiontest/generators_linux_test.go
+++ b/encryptiontest/generators_linux_test.go
@@ -12,6 +12,10 @@ var reliableGenerators = []generatorTestCase{
 	{"ascendingBytes", ascendingBytes, true, false, false},
 	{"pesudorand", pseudorand, false, true, false},
 	{"cryptorand", cryptorand, false, true, true},
-	{"divx", divx, true, false, false},
-	{"zip", zip, true, false, false},
+
+	// divx/zip require a precomputed random file to test with
+	// due to lfs limits this file is no longer being servered by grailbio
+	// The file may be downloaded via LFS from 39b3ca80f18 or earlier
+	//{"divx", divx, true, false, false},
+	//{"zip", zip, true, false, false},
 }

--- a/encryptiontest/testdata/.gitattributes
+++ b/encryptiontest/testdata/.gitattributes
@@ -1,2 +1,0 @@
-dict.zip filter=lfs diff=lfs merge=lfs -text
-divx-sample.mkv filter=lfs diff=lfs merge=lfs -text

--- a/encryptiontest/testdata/dict.zip
+++ b/encryptiontest/testdata/dict.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1e91189fb55946df4af01b67d1a9658d0d23086c7e61db059bc3c0dbf8441854
-size 80000000

--- a/encryptiontest/testdata/divx-sample.mkv
+++ b/encryptiontest/testdata/divx-sample.mkv
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9cf2e10bb20f653406518ad334d61d0ff350acc6141f3496aeb55293a80021ba
-size 80000000


### PR DESCRIPTION
As number of clones has exceed 2k each time a new change to this library is made - remove the LFS files and related tests.