### PR TITLE
Upgrade golangci-lint-action to v1.29

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Check out
       uses: actions/checkout@v2
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v1
+      uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.27
+        version: v1.29
         only-new-issues: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [1.12, 1.13, 1.14]
+        go: [1.13, 1.14, 1.15]
     name: Build & Test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [1.13, 1.14, 1.15]
+        go: [1.13, 1.14, 1.15, 1.16]
     name: Build & Test
     runs-on: ubuntu-latest
     steps:

--- a/go.mod
+++ b/go.mod
@@ -18,3 +18,5 @@ require (
 )
 
 replace git.apache.org/thrift.git => github.com/apache/thrift v0.12.0
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSR
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/aws/aws-sdk-go v1.23.14 h1:fgBFQhTYvfckw0HH9e1W/l70PX6n3InFEQgrc9hNCRk=
 github.com/aws/aws-sdk-go v1.23.14/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.23.22 h1:6zwCJ9X8NMizf4wMEGQjqTUV+otsB+NwyJftt2Ua9Oo=
 github.com/aws/aws-sdk-go v1.23.22/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=


### PR DESCRIPTION
This upgrades works with the `set-env` vulnerability fix in GitHub Actions.  See https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/ .

Along the way, fix up `go.mod` and `go.sum` and update CI build matrix Go versions so that everything builds correctly.